### PR TITLE
make selector more specific, so only selects items within the footer

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -16,10 +16,9 @@
 update_footer = (owner, authUser) ->
   # we update the state of both the owner, and login/out in the footer
 
-  $('footer > #site-owner').empty()
-
+  # only change the owner if we have been passed an owner
   if owner
-    $('footer > #site-owner').append "Site Owned by: <span id='site-owner' style='text-transform:capitalize;'>#{owner}</span>"
+    $('footer > #site-owner').html("Site Owned by: <span id='site-owner' style='text-transform:capitalize;'>#{owner}</span>")
 
   $('footer > #security').empty()
 

--- a/client/security.coffee
+++ b/client/security.coffee
@@ -16,21 +16,21 @@
 update_footer = (owner, authUser) ->
   # we update the state of both the owner, and login/out in the footer
 
-  $('#site-owner').empty()
+  $('footer > #site-owner').empty()
 
   if owner
-    $('#site-owner').append "Site Owned by: <span id='site-owner' style='text-transform:capitalize;'>#{owner}</span>"
+    $('footer > #site-owner').append "Site Owned by: <span id='site-owner' style='text-transform:capitalize;'>#{owner}</span>"
 
-  $('#security').empty()
+  $('footer > #security').empty()
 
   if authUser is true
-    $('#security').append "<a href='#' class='persona-button' id='persona-logout-btn'><span>Sign Out</span></a>"
-    $('#persona-logout-btn').click (e) ->
+    $('footer > #security').append "<a href='#' class='persona-button' id='persona-logout-btn'><span>Sign Out</span></a>"
+    $('footer > #security > #persona-logout-btn').click (e) ->
       e.preventDefault()
       navigator.id.logout {}
   else
-    $('#security').append "<a href='#' class='persona-button' id='persona-login-btn'><span>Sign in with your Email</span></a>"
-    $('#persona-login-btn').click (e) ->
+    $('footer > #security').append "<a href='#' class='persona-button' id='persona-login-btn'><span>Sign in with your Email</span></a>"
+    $('footer > #security > #persona-login-btn').click (e) ->
       e.preventDefault()
       navigator.id.request {}
 


### PR DESCRIPTION
Be a lot more specific about the items we select - so only looking for items within the footer. So, we don't mistake a page with the same name as the item we are looking for.

Fixes for #1
